### PR TITLE
Package can take req with triple-equals

### DIFF
--- a/pipfreeze/package.py
+++ b/pipfreeze/package.py
@@ -58,7 +58,7 @@ class Package(object):
 
         # Ensure we're dealing with an exact package version
         if len(self._req.specifiers) != 1 or \
-                self._req.specifiers[0][0] != '==':
+                self._req.specifiers[0][0] not in ('==', '==='):
             raise ValueError(
                 '{} does not represent an exact package version; '
                 'the format should be foo==1.0'.format(pinned_requirement)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -3,6 +3,7 @@ import pytest
 
 @pytest.mark.parametrize("req, req_name, req_specs, req_raw, req_id, req_version", [
     ('foobar==1.2', 'foobar', [('==', '1.2')], 'foobar==1.2', 'foobar', '1.2'),
+    ('foobar===1.2', 'foobar', [('===', '1.2')], 'foobar===1.2', 'foobar', '1.2'),
 ])
 def test_package(req, req_name, req_specs, req_raw, req_id, req_version):
     from pipfreeze import Package


### PR DESCRIPTION
The output of pip freeze can return a triple equal sign and is a valid
requirement according to the spec pkg_resources spec:

https://pythonhosted.org/setuptools/pkg_resources.html#requirements-parsing